### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: returntocorp/semgrep@sha256:23d35d237018888368138f16446ab3c68e737417a81743e3f1b95dd7e22ad65c
+      image: returntocorp/semgrep:1.2.1@sha256:6d942656477431536ca7cbeee3665ae5a4a2ca765f8f67ed5edfffb7cf20e5a2
 
     steps:
       - name: Check out repo

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: returntocorp/semgrep:1.2.1@sha256:6d942656477431536ca7cbeee3665ae5a4a2ca765f8f67ed5edfffb7cf20e5a2
+      image: returntocorp/semgrep:1.2.1@sha256:4569a843328958ef6f651a06b9696fbbc4c844d7d8a174fe22fb9b9795802db1
 
     steps:
       - name: Check out repo

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: returntocorp/semgrep:1.2.1@sha256:4569a843328958ef6f651a06b9696fbbc4c844d7d8a174fe22fb9b9795802db1
+      image: returntocorp/semgrep:1.12.1@sha256:23d35d237018888368138f16446ab3c68e737417a81743e3f1b95dd7e22ad65c
 
     steps:
       - name: Check out repo

--- a/package-lock.json
+++ b/package-lock.json
@@ -5666,9 +5666,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/lru-cache": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.16.1.tgz",
+      "integrity": "sha512-9kkuMZHnLH/8qXARvYSjNvq8S1GYFFzynQTAfKeaJ0sIrR3PUPuu37Z+EiIANiZBvpfTf2B5y8ecDLSMWlLv+w==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -6455,9 +6455,9 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.0.tgz",
+      "integrity": "sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",


### PR DESCRIPTION
- fix: lock down with version and digest
- chore(deps): update returntocorp/semgrep:1.2.1 docker digest to 4569a84
- chore(deps): update returntocorp/semgrep docker tag to v1.12.1
- chore(deps): lock file maintenance
