### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,7 +625,7 @@ jobs:
       # since we deal with tags (mutable), and the way to get a digest is to use the tag, I prefer
       # sourcing the digest from the local registry we just spun up (trusted)
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         id: attestation
         with:
           subject-name: ${{ needs.docker-build.outputs.full_image_name_remote_registry }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: returntocorp/semgrep:1.133.0@sha256:a780bb007d9a6941f427ced0d534359691edf92f0af7fdfe4e2a61c1cb56b10d
+      image: returntocorp/semgrep:1.134.0@sha256:4eb1dee397683d976f525d689d42d9023617c1c886abae9e4a4590aa96e05028
 
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,10 @@ RUN cargo init --name ${APPLICATION_NAME}
 
 COPY ./.cargo ./Cargo.toml ./Cargo.lock ./
 
-RUN --mount=type=cache,target=/build/target,sharing=locked \
+RUN --mount=type=cache,target=/build/target/${TARGET},sharing=locked \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \
     --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    /build-scripts/build.sh build --release --target ${TARGET}
+    /build-scripts/build.sh build --release --target ${TARGET} --target-dir ./target/${TARGET}
 
 # Rust full build
 FROM rust-cargo-build AS rust-build
@@ -63,10 +63,10 @@ COPY ./src ./src
 RUN touch ./src/main.rs
 
 # --release not needed, it is implied with install
-RUN --mount=type=cache,target=/build/target,sharing=locked \
+RUN --mount=type=cache,target=/build/target/${TARGET},sharing=locked \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \
     --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    /build-scripts/build.sh install --path . --locked --target ${TARGET} --root /output
+    /build-scripts/build.sh install --path . --locked --target ${TARGET} --target-dir ./target/${TARGET} --root /output
 
 # Container user setup
 FROM --platform=${BUILDPLATFORM} alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS passwd-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,21 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
         build-essential \
         musl-dev
 
+# The following block
+# creates an empty app, and we copy in Cargo.toml and Cargo.lock as they represent our dependencies
+# This allows us to copy in the source in a different layer which in turn allows us to leverage Docker's layer caching
+# That means that if our dependencies don't change rebuilding is much faster
+WORKDIR /build
+
+RUN cargo init --name ${APPLICATION_NAME}
+
+COPY ./.cargo ./Cargo.toml ./Cargo.lock ./
+
+# We use `fetch` to pre-download the files to the cache
+RUN --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
+    --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    cargo fetch
+
 FROM rust-base AS rust-linux-amd64
 ARG TARGET=x86_64-unknown-linux-musl
 
@@ -35,16 +50,6 @@ RUN --mount=type=cache,id=apt-cache-${TARGET},from=rust-base,target=/var/cache/a
     /build-scripts/setup-env.sh
 
 RUN rustup target add ${TARGET}
-
-# The following block
-# creates an empty app, and we copy in Cargo.toml and Cargo.lock as they represent our dependencies
-# This allows us to copy in the source in a different layer which in turn allows us to leverage Docker's layer caching
-# That means that if our dependencies don't change rebuilding is much faster
-WORKDIR /build
-
-RUN cargo init --name ${APPLICATION_NAME}
-
-COPY ./.cargo ./Cargo.toml ./Cargo.lock ./
 
 RUN --mount=type=cache,target=/build/target/${TARGET},sharing=locked \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "packageManager": "pnpm@10.15.0",
   "engines": {
-    "node": "22.18.0",
+    "node": "24.7.0",
     "pnpm": "10.15.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "packageManager": "pnpm@10.15.0",
   "engines": {
-    "node": "22.18.0",
+    "node": "22.19.0",
     "pnpm": "10.15.0"
   },
   "scripts": {


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.134.0**
- **feat: write output to per-target folder, otherwise caches overwrite each other causing recompilation in the install step**
- **fix: pre-cache**
- **chore(deps): update node.js to v22.19.0**
- **chore(deps): update actions/attest-build-provenance action to v3**
- **chore: remove submodule folder**
