### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: returntocorp/semgrep:1.145.1@sha256:83427ff52357f0e34f2abdba861fcdf215175a9fb93dbc5113a92fcc73126689
+      image: returntocorp/semgrep:1.145.2@sha256:791a85e244b61e83ef96364997fd069f33e78ce2c4b5541d7bee22f07ee117c9
 
     steps:
       - name: Checkout

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>kristof-mattei/renovate-config",
+        "github>kristof-mattei/renovate-config//github-actions/nonSemver",
         "github>kristof-mattei/renovate-config//rust/updateRustVersionInCargoToml",
         "github>kristof-mattei/renovate-config//rust/updateChannelInRustToolchainToml"
     ]


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.145.2**
- **chore: add exception for non-semver github actions, allowing full-semver all, and non-semver for packages like `mold`**
