### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -134,7 +134,7 @@ jobs:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           tags: |
             type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
-            type=semver,pattern=v{{version}}
+            type=semver,pattern={{version}},prefix=v
 
       - name: Actually re-tag the container
         shell: bash

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   spellcheck:
     name: Spellcheck
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
- **fix: ensure pre-release and release tags on containers are emitted with the 'v' prefix**
- **fix: skip spellcheck on release/ branches**
